### PR TITLE
Update readme template/generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with quantum computers.
 ## Build Matrix
 
 - Ocean: [`6.7.1`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/6.7.1)
-- Python: `3.8` (except on Windows), `3.9`, **`3.10`** (default), `3.11`
+- Python: `3.8` (except on `windowsservercore`), `3.9`, `3.10`, `3.11` (default), `3.12`
 - Platform: [`bullseye`](https://wiki.debian.org/DebianBullseye), `slim` (minimal bullseye), `windowsservercore`
 
 
@@ -29,44 +29,6 @@ Architecture can be shared, though; Linux simple tags point to multi-arch images
 Shared tags map to multi-platform/multi-architecture images.
 
 ### Simple Tags
-
-- [Ocean: `6.7.1`, Python: `3.11`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/bullseye/Dockerfile)
-  - `6-bullseye`
-  - `6-python3.11-bullseye`
-  - `6.7-bullseye`
-  - `6.7-python3.11-bullseye`
-  - `6.7.1-bullseye`
-  - `6.7.1-python3.11-bullseye`
-  - `bullseye`
-  - `python3.11-bullseye`
-
-- [Ocean: `6.7.1`, Python: `3.11`, Platform: `slim-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/slim-bullseye/Dockerfile)
-  - `6-python3.11-slim`
-  - `6-python3.11-slim-bullseye`
-  - `6-slim`
-  - `6-slim-bullseye`
-  - `6.7-python3.11-slim`
-  - `6.7-python3.11-slim-bullseye`
-  - `6.7-slim`
-  - `6.7-slim-bullseye`
-  - `6.7.1-python3.11-slim`
-  - `6.7.1-python3.11-slim-bullseye`
-  - `6.7.1-slim`
-  - `6.7.1-slim-bullseye`
-  - `python3.11-slim`
-  - `python3.11-slim-bullseye`
-  - `slim`
-  - `slim-bullseye`
-
-- [Ocean: `6.7.1`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/windowsservercore/Dockerfile)
-  - `6-python3.11-windowsservercore`
-  - `6-windowsservercore`
-  - `6.7-python3.11-windowsservercore`
-  - `6.7-windowsservercore`
-  - `6.7.1-python3.11-windowsservercore`
-  - `6.7.1-windowsservercore`
-  - `python3.11-windowsservercore`
-  - `windowsservercore`
 
 - [Ocean: `6.7.1`, Python: `3.8`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.8/bullseye/Dockerfile)
   - `6-python3.8-bullseye`
@@ -128,6 +90,44 @@ Shared tags map to multi-platform/multi-architecture images.
   - `6.7.1-python3.10-windowsservercore`
   - `python3.10-windowsservercore`
 
+- [Ocean: `6.7.1`, Python: `3.11`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/bullseye/Dockerfile)
+  - `6-bullseye`
+  - `6-python3.11-bullseye`
+  - `6.7-bullseye`
+  - `6.7-python3.11-bullseye`
+  - `6.7.1-bullseye`
+  - `6.7.1-python3.11-bullseye`
+  - `bullseye`
+  - `python3.11-bullseye`
+
+- [Ocean: `6.7.1`, Python: `3.11`, Platform: `slim-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/slim-bullseye/Dockerfile)
+  - `6-python3.11-slim`
+  - `6-python3.11-slim-bullseye`
+  - `6-slim`
+  - `6-slim-bullseye`
+  - `6.7-python3.11-slim`
+  - `6.7-python3.11-slim-bullseye`
+  - `6.7-slim`
+  - `6.7-slim-bullseye`
+  - `6.7.1-python3.11-slim`
+  - `6.7.1-python3.11-slim-bullseye`
+  - `6.7.1-slim`
+  - `6.7.1-slim-bullseye`
+  - `python3.11-slim`
+  - `python3.11-slim-bullseye`
+  - `slim`
+  - `slim-bullseye`
+
+- [Ocean: `6.7.1`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.11/windowsservercore/Dockerfile)
+  - `6-python3.11-windowsservercore`
+  - `6-windowsservercore`
+  - `6.7-python3.11-windowsservercore`
+  - `6.7-windowsservercore`
+  - `6.7.1-python3.11-windowsservercore`
+  - `6.7.1-windowsservercore`
+  - `python3.11-windowsservercore`
+  - `windowsservercore`
+
 - [Ocean: `6.7.1`, Python: `3.12`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.12/bullseye/Dockerfile)
   - `6-python3.12-bullseye`
   - `6.7-python3.12-bullseye`
@@ -153,6 +153,10 @@ Shared tags map to multi-platform/multi-architecture images.
 
 ### Shared Tags
 
+- `6-python3.9`, `6.7-python3.9`, `6.7.1-python3.9`, `python3.9`
+  - [`6.7.1-python3.9-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.9/bullseye/Dockerfile)
+  - [`6.7.1-python3.9-windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.9/windowsservercore/Dockerfile)
+
 - `6-python3.10`, `6.7-python3.10`, `6.7.1-python3.10`, `python3.10`
   - [`6.7.1-python3.10-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.10/bullseye/Dockerfile)
   - [`6.7.1-python3.10-windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.10/windowsservercore/Dockerfile)
@@ -164,10 +168,6 @@ Shared tags map to multi-platform/multi-architecture images.
 - `6-python3.12`, `6.7-python3.12`, `6.7.1-python3.12`, `python3.12`
   - [`6.7.1-python3.12-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.12/bullseye/Dockerfile)
   - [`6.7.1-python3.12-windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.12/windowsservercore/Dockerfile)
-
-- `6-python3.9`, `6.7-python3.9`, `6.7.1-python3.9`, `python3.9`
-  - [`6.7.1-python3.9-bullseye`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.9/bullseye/Dockerfile)
-  - [`6.7.1-python3.9-windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/6/python3.9/windowsservercore/Dockerfile)
 
 
 

--- a/README.md.template
+++ b/README.md.template
@@ -8,7 +8,7 @@ with quantum computers.
 ## Build Matrix
 
 - Ocean: [`{{ ocean_version }}`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/{{ ocean_version }})
-- Python: `3.8` (except on Windows), `3.9`, **`3.10`** (default), `3.11`
+- Python: {{#strip}}{{#python_versions}}`{{version}}`{{#excluded}} (except on `{{.}}`){{/excluded}}{{#default}} (default){{/default}}, {{/python_versions}}{{/strip}}
 - Platform: [`bullseye`](https://wiki.debian.org/DebianBullseye), `slim` (minimal bullseye), `windowsservercore`
 
 

--- a/generate.py
+++ b/generate.py
@@ -306,11 +306,22 @@ def readme(template, output):
                           for c_tag in sorted(shared[tags[0]])]
         })
 
+    # construct a list of python versions, together with exclusions and defaults
+    _join_platforms = lambda rules: ', '.join(r['platform'] for r in rules)
+    python_versions = []
+    for py in filter(None, build.python_versions):
+        python_versions.append({"version": py,
+                                "default": py == build.config['defaults'].get('python'),
+                                "excluded": _join_platforms(
+                                    filter(lambda rule: rule.get('python') == py,
+                                           build.config['exclude']))})
+
     def f_strip(text, render):
         return render(text).strip(' ,')
 
     readme = chevron.render(template.read(), data=dict(
         ocean_version=build.ocean_version,
+        python_versions=python_versions,
         simple_tags=simple_tags,
         shared_tags=shared_tags,
         strip=f_strip))

--- a/generate.py
+++ b/generate.py
@@ -285,11 +285,20 @@ def readme(template, output):
                     "subtags": simple.canonical[c_tag]}
                    for c_tag, a_tags in simple.bags.items()]
 
+    # order by (ocean version, python version, platform) for display purposes
+    parse_version = lambda s: tuple(map(int, s.split('.')))
+    versions_tuple = lambda subtags: (parse_version(subtags['ocean']),
+                                      parse_version(subtags['python']),
+                                      subtags['platform'])
+    simple_tags.sort(key=lambda tag: versions_tuple(tag['subtags']))
+
     _key = lambda tag: ','.join(sorted(shared[tag]))
-    grouped = groupby(sorted(shared, key=_key), key=_key)
+    grouped = [sorted(g) for _, g in groupby(sorted(shared, key=_key), key=_key)]
+    grouped.sort(key=lambda tags: versions_tuple(
+        subtags=simple.canonical[next(iter(shared[tags[0]]))]
+    ))
     shared_tags = []
-    for _, g in grouped:
-        tags = sorted(g)
+    for tags in grouped:
         shared_tags.append({
             "tags": tags,
             "canonical": [{"tag": c_tag,


### PR DESCRIPTION
- make tag order stable (order by canonical tag's `(ocean, python, platform)` tuple, using version sort for ocean and python versions).
- generate python versions (with exclusions and defaults marked)