### PR TITLE
Add debian trixie images

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -244,14 +244,24 @@ workflows:
               path: &linux-dockerfiles [
                 "dockerfiles/9/python3.9/bookworm",
                 "dockerfiles/9/python3.9/slim-bookworm",
+                "dockerfiles/9/python3.9/trixie",
+                "dockerfiles/9/python3.9/slim-trixie",
                 "dockerfiles/9/python3.10/bookworm",
                 "dockerfiles/9/python3.10/slim-bookworm",
+                "dockerfiles/9/python3.10/trixie",
+                "dockerfiles/9/python3.10/slim-trixie",
                 "dockerfiles/9/python3.11/bookworm",
                 "dockerfiles/9/python3.11/slim-bookworm",
+                "dockerfiles/9/python3.11/trixie",
+                "dockerfiles/9/python3.11/slim-trixie",
                 "dockerfiles/9/python3.12/bookworm",
                 "dockerfiles/9/python3.12/slim-bookworm",
+                "dockerfiles/9/python3.12/trixie",
+                "dockerfiles/9/python3.12/slim-trixie",
                 "dockerfiles/9/python3.13/bookworm",
                 "dockerfiles/9/python3.13/slim-bookworm",
+                "dockerfiles/9/python3.13/trixie",
+                "dockerfiles/9/python3.13/slim-trixie",
               ]
           filters: &off-master
             branches:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ with quantum computers.
 
 - Ocean: [`9.0.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/9.0.0)
 - Python: `3.9`, `3.10`, `3.11`, `3.12` (default), `3.13`
-- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm), `slim` (minimal bookworm), `windowsservercore`
+- Platform:
+    [`trixie`](https://wiki.debian.org/DebianTrixie),
+    `slim-trixie` (minimal trixie),
+    [`bookworm`](https://wiki.debian.org/DebianBookworm) (default),
+    `slim` (minimal bookworm),
+    `windowsservercore`
 
 
 ## Architectures
@@ -46,6 +51,18 @@ Shared tags map to multi-platform/multi-architecture images.
   - `python3.9-slim`
   - `python3.9-slim-bookworm`
 
+- [Ocean: `9.0.0`, Python: `3.9`, Platform: `slim-trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.9/slim-trixie/Dockerfile)
+  - `9-python3.9-slim-trixie`
+  - `9.0-python3.9-slim-trixie`
+  - `9.0.0-python3.9-slim-trixie`
+  - `python3.9-slim-trixie`
+
+- [Ocean: `9.0.0`, Python: `3.9`, Platform: `trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.9/trixie/Dockerfile)
+  - `9-python3.9-trixie`
+  - `9.0-python3.9-trixie`
+  - `9.0.0-python3.9-trixie`
+  - `python3.9-trixie`
+
 - [Ocean: `9.0.0`, Python: `3.9`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.9/windowsservercore/Dockerfile)
   - `9-python3.9-windowsservercore`
   - `9.0-python3.9-windowsservercore`
@@ -68,6 +85,18 @@ Shared tags map to multi-platform/multi-architecture images.
   - `python3.10-slim`
   - `python3.10-slim-bookworm`
 
+- [Ocean: `9.0.0`, Python: `3.10`, Platform: `slim-trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.10/slim-trixie/Dockerfile)
+  - `9-python3.10-slim-trixie`
+  - `9.0-python3.10-slim-trixie`
+  - `9.0.0-python3.10-slim-trixie`
+  - `python3.10-slim-trixie`
+
+- [Ocean: `9.0.0`, Python: `3.10`, Platform: `trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
+  - `9-python3.10-trixie`
+  - `9.0-python3.10-trixie`
+  - `9.0.0-python3.10-trixie`
+  - `python3.10-trixie`
+
 - [Ocean: `9.0.0`, Python: `3.10`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.10/windowsservercore/Dockerfile)
   - `9-python3.10-windowsservercore`
   - `9.0-python3.10-windowsservercore`
@@ -89,6 +118,18 @@ Shared tags map to multi-platform/multi-architecture images.
   - `9.0.0-python3.11-slim-bookworm`
   - `python3.11-slim`
   - `python3.11-slim-bookworm`
+
+- [Ocean: `9.0.0`, Python: `3.11`, Platform: `slim-trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.11/slim-trixie/Dockerfile)
+  - `9-python3.11-slim-trixie`
+  - `9.0-python3.11-slim-trixie`
+  - `9.0.0-python3.11-slim-trixie`
+  - `python3.11-slim-trixie`
+
+- [Ocean: `9.0.0`, Python: `3.11`, Platform: `trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
+  - `9-python3.11-trixie`
+  - `9.0-python3.11-trixie`
+  - `9.0.0-python3.11-trixie`
+  - `python3.11-trixie`
 
 - [Ocean: `9.0.0`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.11/windowsservercore/Dockerfile)
   - `9-python3.11-windowsservercore`
@@ -124,6 +165,26 @@ Shared tags map to multi-platform/multi-architecture images.
   - `slim`
   - `slim-bookworm`
 
+- [Ocean: `9.0.0`, Python: `3.12`, Platform: `slim-trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.12/slim-trixie/Dockerfile)
+  - `9-python3.12-slim-trixie`
+  - `9-slim-trixie`
+  - `9.0-python3.12-slim-trixie`
+  - `9.0-slim-trixie`
+  - `9.0.0-python3.12-slim-trixie`
+  - `9.0.0-slim-trixie`
+  - `python3.12-slim-trixie`
+  - `slim-trixie`
+
+- [Ocean: `9.0.0`, Python: `3.12`, Platform: `trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
+  - `9-python3.12-trixie`
+  - `9-trixie`
+  - `9.0-python3.12-trixie`
+  - `9.0-trixie`
+  - `9.0.0-python3.12-trixie`
+  - `9.0.0-trixie`
+  - `python3.12-trixie`
+  - `trixie`
+
 - [Ocean: `9.0.0`, Python: `3.12`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.12/windowsservercore/Dockerfile)
   - `9-python3.12-windowsservercore`
   - `9-windowsservercore`
@@ -149,6 +210,18 @@ Shared tags map to multi-platform/multi-architecture images.
   - `9.0.0-python3.13-slim-bookworm`
   - `python3.13-slim`
   - `python3.13-slim-bookworm`
+
+- [Ocean: `9.0.0`, Python: `3.13`, Platform: `slim-trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.13/slim-trixie/Dockerfile)
+  - `9-python3.13-slim-trixie`
+  - `9.0-python3.13-slim-trixie`
+  - `9.0.0-python3.13-slim-trixie`
+  - `python3.13-slim-trixie`
+
+- [Ocean: `9.0.0`, Python: `3.13`, Platform: `trixie`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
+  - `9-python3.13-trixie`
+  - `9.0-python3.13-trixie`
+  - `9.0.0-python3.13-trixie`
+  - `python3.13-trixie`
 
 - [Ocean: `9.0.0`, Python: `3.13`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-docker/blob/master/dockerfiles/9/python3.13/windowsservercore/Dockerfile)
   - `9-python3.13-windowsservercore`

--- a/README.md.template
+++ b/README.md.template
@@ -9,7 +9,12 @@ with quantum computers.
 
 - Ocean: [`{{ ocean_version }}`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/{{ ocean_version }})
 - Python: {{#strip}}{{#python_versions}}`{{version}}`{{#excluded}} (except on `{{.}}`){{/excluded}}{{#default}} (default){{/default}}, {{/python_versions}}{{/strip}}
-- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm), `slim` (minimal bookworm), `windowsservercore`
+- Platform:
+    [`trixie`](https://wiki.debian.org/DebianTrixie),
+    `slim-trixie` (minimal trixie),
+    [`bookworm`](https://wiki.debian.org/DebianBookworm) (default),
+    `slim` (minimal bookworm),
+    `windowsservercore`
 
 
 ## Architectures

--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
     "matrix": {
         "ocean": [null, "{ocean.major}", "{ocean.minor}", "{ocean.patch}"],
         "python": [null, "3.9", "3.10", "3.11", "3.12", "3.13"],
-        "platform": ["bookworm", "slim-bookworm", "slim", "windowsservercore"]
+        "platform": ["trixie", "slim-trixie", "bookworm", "slim-bookworm", "slim", "windowsservercore"]
     },
     "exclude": [],
     "aliases": {
@@ -20,10 +20,12 @@
     },
     "template": {
         "Dockerfile-linux-slim.template": [
-            {"platform": "slim-bookworm"}
+            {"platform": "slim-bookworm"},
+            {"platform": "slim-trixie"}
         ],
         "Dockerfile-linux.template": [
-            {"platform": "bookworm"}
+            {"platform": "bookworm"},
+            {"platform": "trixie"}
         ],
         "Dockerfile-windows.template": [
             {"platform": "windowsservercore"}

--- a/dockerfiles/9/python3.10/slim-trixie/Dockerfile
+++ b/dockerfiles/9/python3.10/slim-trixie/Dockerfile
@@ -1,0 +1,20 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.10-slim-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential git \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && apt-get remove -yq build-essential git \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.10/slim-trixie/tags.json
+++ b/dockerfiles/9/python3.10/slim-trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.10-slim-trixie",
+  "alias_tags": [
+    "9-python3.10-slim-trixie",
+    "9.0-python3.10-slim-trixie",
+    "python3.10-slim-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.10",
+    "platform": "slim-trixie"
+  }
+}

--- a/dockerfiles/9/python3.10/trixie/Dockerfile
+++ b/dockerfiles/9/python3.10/trixie/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.10-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        man-db \
+        curl \
+        htop \
+        less \
+        git \
+        vim \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && rm -rf /tmp/*
+
+RUN pip install --no-cache-dir \
+        ipython \
+    && rm -rf /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.10/trixie/tags.json
+++ b/dockerfiles/9/python3.10/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.10-trixie",
+  "alias_tags": [
+    "9-python3.10-trixie",
+    "9.0-python3.10-trixie",
+    "python3.10-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.10",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.11/slim-trixie/Dockerfile
+++ b/dockerfiles/9/python3.11/slim-trixie/Dockerfile
@@ -1,0 +1,20 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.11-slim-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential git \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && apt-get remove -yq build-essential git \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.11/slim-trixie/tags.json
+++ b/dockerfiles/9/python3.11/slim-trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.11-slim-trixie",
+  "alias_tags": [
+    "9-python3.11-slim-trixie",
+    "9.0-python3.11-slim-trixie",
+    "python3.11-slim-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.11",
+    "platform": "slim-trixie"
+  }
+}

--- a/dockerfiles/9/python3.11/trixie/Dockerfile
+++ b/dockerfiles/9/python3.11/trixie/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.11-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        man-db \
+        curl \
+        htop \
+        less \
+        git \
+        vim \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && rm -rf /tmp/*
+
+RUN pip install --no-cache-dir \
+        ipython \
+    && rm -rf /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.11/trixie/tags.json
+++ b/dockerfiles/9/python3.11/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.11-trixie",
+  "alias_tags": [
+    "9-python3.11-trixie",
+    "9.0-python3.11-trixie",
+    "python3.11-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.11",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.12/slim-trixie/Dockerfile
+++ b/dockerfiles/9/python3.12/slim-trixie/Dockerfile
@@ -1,0 +1,20 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.12-slim-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential git \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && apt-get remove -yq build-essential git \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.12/slim-trixie/tags.json
+++ b/dockerfiles/9/python3.12/slim-trixie/tags.json
@@ -1,0 +1,17 @@
+{
+  "canonical_tag": "9.0.0-python3.12-slim-trixie",
+  "alias_tags": [
+    "9-python3.12-slim-trixie",
+    "9-slim-trixie",
+    "9.0-python3.12-slim-trixie",
+    "9.0-slim-trixie",
+    "9.0.0-slim-trixie",
+    "python3.12-slim-trixie",
+    "slim-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.12",
+    "platform": "slim-trixie"
+  }
+}

--- a/dockerfiles/9/python3.12/trixie/Dockerfile
+++ b/dockerfiles/9/python3.12/trixie/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.12-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        man-db \
+        curl \
+        htop \
+        less \
+        git \
+        vim \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && rm -rf /tmp/*
+
+RUN pip install --no-cache-dir \
+        ipython \
+    && rm -rf /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.12/trixie/tags.json
+++ b/dockerfiles/9/python3.12/trixie/tags.json
@@ -1,0 +1,17 @@
+{
+  "canonical_tag": "9.0.0-python3.12-trixie",
+  "alias_tags": [
+    "9-python3.12-trixie",
+    "9-trixie",
+    "9.0-python3.12-trixie",
+    "9.0-trixie",
+    "9.0.0-trixie",
+    "python3.12-trixie",
+    "trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.12",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.13/slim-trixie/Dockerfile
+++ b/dockerfiles/9/python3.13/slim-trixie/Dockerfile
@@ -1,0 +1,20 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.13-slim-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential git \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && apt-get remove -yq build-essential git \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.13/slim-trixie/tags.json
+++ b/dockerfiles/9/python3.13/slim-trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.13-slim-trixie",
+  "alias_tags": [
+    "9-python3.13-slim-trixie",
+    "9.0-python3.13-slim-trixie",
+    "python3.13-slim-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.13",
+    "platform": "slim-trixie"
+  }
+}

--- a/dockerfiles/9/python3.13/trixie/Dockerfile
+++ b/dockerfiles/9/python3.13/trixie/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.13-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        man-db \
+        curl \
+        htop \
+        less \
+        git \
+        vim \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && rm -rf /tmp/*
+
+RUN pip install --no-cache-dir \
+        ipython \
+    && rm -rf /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.13/trixie/tags.json
+++ b/dockerfiles/9/python3.13/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.13-trixie",
+  "alias_tags": [
+    "9-python3.13-trixie",
+    "9.0-python3.13-trixie",
+    "python3.13-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.13",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.9/slim-trixie/Dockerfile
+++ b/dockerfiles/9/python3.9/slim-trixie/Dockerfile
@@ -1,0 +1,20 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.9-slim-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential git \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && apt-get remove -yq build-essential git \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.9/slim-trixie/tags.json
+++ b/dockerfiles/9/python3.9/slim-trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.9-slim-trixie",
+  "alias_tags": [
+    "9-python3.9-slim-trixie",
+    "9.0-python3.9-slim-trixie",
+    "python3.9-slim-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.9",
+    "platform": "slim-trixie"
+  }
+}

--- a/dockerfiles/9/python3.9/trixie/Dockerfile
+++ b/dockerfiles/9/python3.9/trixie/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.9-trixie
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        man-db \
+        curl \
+        htop \
+        less \
+        git \
+        vim \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+    && rm -rf /tmp/*
+
+RUN pip install --no-cache-dir \
+        ipython \
+    && rm -rf /tmp/*
+
+CMD ["python"]

--- a/dockerfiles/9/python3.9/trixie/tags.json
+++ b/dockerfiles/9/python3.9/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.9-trixie",
+  "alias_tags": [
+    "9-python3.9-trixie",
+    "9.0-python3.9-trixie",
+    "python3.9-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.9",
+    "platform": "trixie"
+  }
+}


### PR DESCRIPTION
[Trixie](https://www.debian.org/releases/trixie/) is the current "stable" release [as of 2025-08-09](https://www.debian.org/releases/).